### PR TITLE
Lots of changes, mainly n-gons

### DIFF
--- a/shape.lua
+++ b/shape.lua
@@ -340,7 +340,7 @@ end
 -- I *HIGHLY* suggest formatting all shape subroutines to use the format that dome() uses;  specifically, navigateTo(x,y,z) placeBlock().  This should ensure proper "data recording" and alos makes readability better
 function navigateTo(targetx, targety, targetz, moveZFirst)
 	targetz = targetz or positionz -- if targetz isn't used in the function call it defaults to its current z position, this should make it compatible with all current implementations of navigateTo()
-	moveZFirst = moveZFirst or false -- default to moving z last
+	moveZFirst = moveZFirst or false -- default to moving z last, if true is passed as last argument, it moves vertically first
 	
 	if moveZFirst then
 		moveZ(targetz)


### PR DESCRIPTION
I've added the following:
- A second page for shape choices
- Hexagons: on the second page, builds regular hexagons
- Octagons: on the second page, also regular
- Hexagonal Prisms: on the second page, like cylinders but with hexagons
- Octagonal Prisms: on the second page, like cylinders but with octagons
- `goHome()`: moves the turtle to 0,0,0 and makes it face 0
- `turnToFace()`: rotates the turtle to face the direction passed as an argument

---

I've changed:
- Moved the sphere to page 2 because it was where I put "next" on page 1
- Replaced all things that do the same as `goHome()` with `goHome()`
- Put `goHome()` in the if statements  in `Choicefunct()` and removed them from the shape building functions
- Made `navigateTo()` take x,y,z coordinates
  - If only x,y is given z defaults to the turtle's current z position
  - Moves vertically last by default, unless `true` is passed as fourth argument
- Changed the code in `moveZ()` to be similar to `moveX()`, `moveY()`
- `safeUp()` and `safeDown()` now increment/decrement positionz to facilitate `navigateTo(x,y,z)`'s vertical component

---

I hope you don't mind me messing with `moveZ()` :sweat: but I thought that I might as well. I'm pretty sure it shouldn't change anything as it currently works because of the default z value in `navigateTo()`.
