### PR TITLE
Command Line Access

### DIFF
--- a/shape.lua
+++ b/shape.lua
@@ -968,11 +968,13 @@ end
 function Choicefunct()
 	if sim_mode == false and cmd_line == false then -- if we are NOT resuming progress
 		choice = io.read()
+		choice = string.lower(choice) -- all checks are aginst lower case words so this is to ensure that
 		temp_prog_table = {shape = choice}
 		prog_table = {shape = choice}
 		if choice == "next" then
 			WriteMenu2()
 			choice = io.read()
+			choice = string.lower(choice) -- all checks are aginst lower case words so this is to ensure that
 		end
 		if choice == "end" or choice == "exit" then
 			writeOut("Goodbye.")
@@ -991,8 +993,10 @@ function Choicefunct()
 	elseif sim_mode == true then -- if we ARE resuming progress
 		temp_prog_table = ReadProgress()
 		choice = temp_prog_table.shape
+		choice = string.lower(choice) -- all checks are aginst lower case words so this is to ensure that
 	elseif cmd_line == true then -- if running from command line
 		choice = temp_prog_table.shape
+		choice = string.lower(choice) -- all checks are aginst lower case words so this is to ensure that
 		writeOut("Building a "..choice)
 	end	
 	if not cost_only then
@@ -1189,6 +1193,7 @@ function Choicefunct()
 		temp_prog_table.param1 = rad
 		temp_prog_table.param2 = half
 		prog_table = {param1 = rad, param2 = half}
+		half = string.lower(half)
 		if half == "bottom" then
 			dome("bowl", rad)
 		else
@@ -1272,7 +1277,7 @@ function Choicefunct()
 		temp_prog_table.param1 = width
 		temp_prog_table.param2 = hollow
 		prog_table = {param1 = width, param2 = hollow}
-		if hollow == 'y' then
+		if hollow == 'y' or hollow == 'yes' or hollow == 'true' then
 			hollow = true
 		else
 			hollow = false


### PR DESCRIPTION
I have tested it in a few different cases and it has worked each time. I am confidant that this works all of the time.

Added:
- Command line access
  - shape.lua takes command line arguments and trys to use them
  - Format: `shape [<type> [param1 param2 ...]] [-c] [-h] [-r] [-z]`
    - -c: set count_only flag to true
    - -h: show help info
    - -r: resume build
    - -z: set chain_next_shape flag to true
  - Work like normal if called without arguments
  - Added a few functions to facilitate this
- Ability to chain multiple shapes together through a flag, the program still has to be run once per shape needed
- Help page
- Help option to page 2
- Exit "shape" closes the program, can be also called with "end", on page 2
- Several flags to help with certain features
- Some other shapes that aren't shown on the menu, but help speed up the program (straight call to bowl/dome.)

---

Changed:
- Added code for `WriteShapeParams()`
- Calls `goHome()` after all shapes are built
- Replaced spaces in names with "-" this makes using them as command line arguments easier, still can be called with the space though
- Made resuming functions recognize command line input
- Made several other functions
- Cleaned up a little bit
- `safeForward()` and `safeBack()` now increment/decrement `positionx` and `positiony` based on facing. This is because some shapes (cough cough, line, cough cough) don't use navigateTo()
- `moveX()` and `moveY()` no longer increment/decrement `positionx` and `positiony`
- `goHome()` now brings the turtle to -1, -1, 0, or 0, 0 if chained
- `goHome()` won't do anything but turn the turtle if special_chain is set to true (used to chain stairs)

---

Known Issues:
- Cost_only will cause the turtle to crash with big shapes >_>
